### PR TITLE
moves default implementation of IRdfConverter to installer

### DIFF
--- a/src/Nancy.Rdf.Tests/ModelBinding/NonJsonLdRdfBodyDeserializerTests.cs
+++ b/src/Nancy.Rdf.Tests/ModelBinding/NonJsonLdRdfBodyDeserializerTests.cs
@@ -23,7 +23,7 @@ namespace Nancy.Rdf.Tests.ModelBinding
         public void Should_support_serialization(RdfSerialization serialization)
         {
             // given
-            var deserializer = new NonJsonLdRdfBodyDeserializer(A.Fake<IEntitySerializer>());
+            var deserializer = new NonJsonLdRdfBodyDeserializer(A.Fake<IEntitySerializer>(), new RdfConverter());
 
             // when
             deserializer.CanDeserialize(serialization.MediaType, new BindingContext());
@@ -34,7 +34,7 @@ namespace Nancy.Rdf.Tests.ModelBinding
         {
             // given
             var entitySerializer = A.Fake<IEntitySerializer>();
-            var binder = new NonJsonLdRdfBodyDeserializer(entitySerializer);
+            var binder = new NonJsonLdRdfBodyDeserializer(entitySerializer, new RdfConverter());
             const string bodyString = "some nquads";
             var body = new MemoryStream(Encoding.UTF8.GetBytes(bodyString));
 

--- a/src/Nancy.Rdf/Installer.cs
+++ b/src/Nancy.Rdf/Installer.cs
@@ -1,6 +1,7 @@
 ﻿using JsonLD.Entities;
 using Nancy.Bootstrapper;
 using Nancy.Rdf.Contexts;
+using Nancy.Rdf.ModelBinding;
 
 namespace Nancy.Rdf
 {
@@ -15,6 +16,7 @@ namespace Nancy.Rdf
         public Installer(ITypeCatalog typeCatalog)
             : base(typeCatalog)
         {
+            this.RegisterWithDefault<IRdfConverter>(typeof(RdfConverter));
             this.RegisterWithDefault<INamespaceManager>(typeof(DictionaryNamespaceManager));
             this.RegisterWithDefault<IContextPathMapper>(typeof(DefaultContextPathMapper));
             this.Register<IEntitySerializer>(typeof(EntitySerializer));

--- a/src/Nancy.Rdf/ModelBinding/NonJsonLdRdfBodyDeserializer.cs
+++ b/src/Nancy.Rdf/ModelBinding/NonJsonLdRdfBodyDeserializer.cs
@@ -24,14 +24,6 @@ namespace Nancy.Rdf.ModelBinding
         /// <summary>
         /// Initializes a new instance of the <see cref="NonJsonLdRdfBodyDeserializer"/> class.
         /// </summary>
-        public NonJsonLdRdfBodyDeserializer(IEntitySerializer serializer)
-            : this(serializer, new RdfConverter())
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NonJsonLdRdfBodyDeserializer"/> class.
-        /// </summary>
         public NonJsonLdRdfBodyDeserializer(
             IEntitySerializer serializer,
             IRdfConverter converter)


### PR DESCRIPTION
this solves an issue which StructureMap has when it tries to resolve the greediest constructor by default