### PR TITLE
Honor x-forwarded-proto when behind proxy

### DIFF
--- a/src/Nancy.Rdf.Tests/RdfResponseProcessorTests.cs
+++ b/src/Nancy.Rdf.Tests/RdfResponseProcessorTests.cs
@@ -115,6 +115,38 @@ namespace Nancy.Rdf.Tests
         }
 
         [Test]
+        public void Should_use_SSL_if_x_Forwarded_Proto_header_present()
+        {
+            // given
+            var serializer = A.Fake<IRdfSerializer>();
+            A.CallTo(() => serializer.CanSerialize(A<MediaRange>.Ignored)).Returns(true);
+            var processor = new RdfResponseProcessorTestable(new[] { serializer });
+
+            var path = new Url("http://example.com/api/test")
+            {
+                BasePath = "api"
+            };
+
+            var nancyContext = new NancyContext
+            {
+                Request = new Request("GET", path, headers: new Dictionary<string, IEnumerable<string>>
+                {
+                    {"X-Forwarded-Proto", new []{"https"}}
+                })
+            };
+
+            // when
+            var response = processor.Process(new MediaRange("application/rdf+xml"), new object(), nancyContext);
+            response.Contents(new MemoryStream());
+
+            // then
+            A.CallTo(() => serializer.Serialize(
+                A<MediaRange>.That.Matches(mr => mr == RdfSerialization.RdfXml.MediaType),
+                A<WrappedModel>.That.Matches(wm => wm.BaseUrl == new Uri("https://example.com:80/")),
+                A<MemoryStream>._)).MustHaveHappened();
+        }
+
+        [Test]
         public void Should_pass_actual_requested()
         {
             // given

--- a/src/Nancy.Rdf/Responses/RdfResponseProcessor.cs
+++ b/src/Nancy.Rdf/Responses/RdfResponseProcessor.cs
@@ -70,11 +70,19 @@ namespace Nancy.Rdf.Responses
         /// <returns>a response</returns>
         public Response Process(MediaRange requestedMediaRange, dynamic model, NancyContext context)
         {
+            var siteBase = context.Request.Url.SiteBase;
+
+            if (context.Request.Headers["X-Forwarded-Proto"].Any(v => v == "https"))
+            {
+                var siteBaseUri = new UriBuilder(siteBase) {Scheme = "HTTPS"};
+                siteBase = siteBaseUri.ToString();
+            }
+
             return new Response
                 {
                     Contents = stream =>
                     {
-                        var wrappedModel = new WrappedModel(model, context.Request.Url.SiteBase);
+                        var wrappedModel = new WrappedModel(model, siteBase);
                         this.serializer.Serialize(requestedMediaRange, wrappedModel, stream);
                     },
                     StatusCode = HttpStatusCode.OK,


### PR DESCRIPTION
`@context` links appended to JSON-LD resources where `ContextPathMap` is used always use the scheme of the locally running server.

With this PR the `X-Forwarded-Proto` header will be inspected to correct the URL behind proxy